### PR TITLE
Add UMD bundle build config and browser usage documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,33 +1,45 @@
 {
-    "name": "sorcherer",
-    "version": "2.0.1",
-    "description": "A library for attaching dynamic HTML overlays to Three.js Object3D instances with distance-based scaling, rotation, auto-centering, and DOM culling.",
-    "main": "index.js",
-    "module": "index.js",
-    "scripts": {
-        "build": "echo \"No build needed\"",
-        "test": "echo \"No tests specified\""
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/yepistream/sorcherer.git"
-    },
-    "keywords": [
-        "threejs",
-        "overlay",
-        "html",
-        "3d",
-        "culling",
-        "sorcherer",
-        "dom"
-    ],
-    "author": "Marko Kazimirovic (yepistream/BamBam/maBBam)",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/yepistream/sorcherer/issues"
-    },
-    "homepage": "https://github.com/yepistream/sorcherer#readme",
-    "dependencies": {
-        "three": "^0.152.2"
-    }
+  "name": "sorcherer",
+  "version": "2.0.1",
+  "description": "A library for attaching dynamic HTML overlays to Three.js Object3D instances with distance-based scaling, rotation, auto-centering, and DOM culling.",
+  "main": "index.js",
+  "module": "index.js",
+  "scripts": {
+    "build": "rollup -c",
+    "test": "echo \"No tests specified\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yepistream/sorcherer.git"
+  },
+  "keywords": [
+    "threejs",
+    "overlay",
+    "html",
+    "3d",
+    "culling",
+    "sorcherer",
+    "dom"
+  ],
+  "author": "Marko Kazimirovic (yepistream/BamBam/maBBam)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/yepistream/sorcherer/issues"
+  },
+  "homepage": "https://github.com/yepistream/sorcherer#readme",
+  "dependencies": {
+    "three": "^0.152.2"
+  },
+  "files": [
+    "dist",
+    "src",
+    "index.js",
+    "magicalStyle.css"
+  ],
+  "unpkg": "dist/sorcherer.umd.min.js",
+  "jsdelivr": "dist/sorcherer.umd.min.js",
+  "devDependencies": {
+    "@rollup/plugin-terser": "^0.4.4",
+    "rollup": "^4.35.0"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@
   - [Installation](#installation)
   - [Usage](#usage)
     - [Importing the Library](#importing-the-library)
+    - [Browser UMD Bundle](#browser-umd-bundle)
     - [Defining Overlays via the `<realm>` Tag](#defining-overlays-via-the-realm-tag)
     - [Example](#example)
   - [API Reference](#api-reference)
@@ -49,6 +50,32 @@ import { Sorcherer } from 'sorcherer';
 ```
 
 Sorcherer expects `three` to be available as an ES module as well.
+
+### Browser UMD Bundle
+
+For script-tag usage, build the UMD bundle:
+
+```bash
+npm run build
+```
+
+This generates:
+
+- `dist/sorcherer.umd.js`
+- `dist/sorcherer.umd.min.js`
+
+The UMD build keeps `three` external, so load Three.js first and ensure it provides the global `THREE`:
+
+```html
+<script src="https://unpkg.com/three@0.152.2/build/three.min.js"></script>
+<script src="./dist/sorcherer.umd.js"></script>
+<script>
+  // UMD export is available on window.Sorcherer
+  const overlay = new window.Sorcherer.Sorcherer(myObject3D);
+  // equivalent:
+  const OverlayCtor = Sorcherer.Sorcherer;
+</script>
+```
 
 ### Defining Overlays via the `<realm>` Tag
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,0 +1,31 @@
+import { terser } from '@rollup/plugin-terser';
+
+export default [
+  {
+    input: 'index.js',
+    output: {
+      file: 'dist/sorcherer.umd.js',
+      format: 'umd',
+      name: 'Sorcherer',
+      globals: {
+        three: 'THREE'
+      },
+      exports: 'named'
+    },
+    external: ['three']
+  },
+  {
+    input: 'index.js',
+    output: {
+      file: 'dist/sorcherer.umd.min.js',
+      format: 'umd',
+      name: 'Sorcherer',
+      globals: {
+        three: 'THREE'
+      },
+      exports: 'named'
+    },
+    external: ['three'],
+    plugins: [terser()]
+  }
+];


### PR DESCRIPTION
### Motivation

- Provide a browser-friendly UMD/IIFE bundle so consumers can use Sorcherer via script tags in non-ESM environments. 
- Keep `three` external for the UMD build and document the required global (`THREE`) and the recommended script load order.

### Description

- Add `rollup.config.mjs` to emit `dist/sorcherer.umd.js` and a minified `dist/sorcherer.umd.min.js` with UMD global name `Sorcherer` and `three` mapped to the global `THREE` (minification via `@rollup/plugin-terser`).
- Update `package.json` to use `"build": "rollup -c"`, publish `dist` via the `files` array, add `unpkg`/`jsdelivr` entries pointing to the minified UMD, and declare `rollup` and `@rollup/plugin-terser` as `devDependencies`.
- Add a `Browser UMD Bundle` section to `readme.md` and update the TOC with an example showing `three` loaded first, then `dist/sorcherer.umd.js`, and usage via `window.Sorcherer`/`Sorcherer.Sorcherer`.

### Testing

- Ran `npm run build`, which failed in this environment with `sh: 1: rollup: not found` because dev dependencies were not installed locally. 
- Attempted `npm install` to install build tools, which failed with a registry `403` error in this environment, preventing a successful build here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bbdb084708331b64008afa8f708d2)