### PR TITLE
Inject Sorcherer styles in JS instead of loading magicalStyle.css

### DIFF
--- a/src/sorcherer.js
+++ b/src/sorcherer.js
@@ -1,14 +1,31 @@
 // src/sorcherer.js
 
-// Dynamically load magicalStyle.css if not already loaded.
-(function loadMagicalStyle() {
+// Dynamically inject Sorcherer styles if not already present.
+(function injectMagicalStyle() {
   if (typeof document !== "undefined" && !document.getElementById('magical-style')) {
-    const link = document.createElement('link');
-    link.id = 'magical-style';
-    link.rel = 'stylesheet';
-    // Adjust the path if your structure changes.
-    link.href = '/magicalStyle.css';
-    document.head.appendChild(link);
+    const style = document.createElement('style');
+    style.id = 'magical-style';
+    style.textContent = `
+.sorcherer-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.magic-MinusOne {
+  position: absolute;
+  color: white;
+  font-family: Arial, sans-serif;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 4px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+`;
+    document.head.appendChild(style);
   }
 })();
 


### PR DESCRIPTION
### Motivation
- Make the library self-contained at runtime by embedding the overlay CSS directly into the JavaScript so it no longer depends on loading `/magicalStyle.css` at runtime.

### Description
- Replaced the runtime `<link href="/magicalStyle.css">` loader in `src/sorcherer.js` with an injected `<style id="magical-style">` element whose `textContent` contains the original `.sorcherer-container` and `.magic-MinusOne` rules and kept the `#magical-style` guard to avoid duplicate injection.

### Testing
- Ran `npm test`, which prints `"No tests specified"`, and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bbc729980833196a473accba4d89d)