### PR TITLE
Fix malformed package.json caused by bad merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,16 +11,8 @@
       "require": "./dist/index.cjs"
     }
   },
-  "files": [
-    "dist",
-    "magicalStyle.css"
-  ],
   "scripts": {
-    "build": "node scripts/build.mjs",
-  "main": "index.js",
-  "module": "index.js",
-  "scripts": {
-    "build": "rollup -c",
+    "build": "node scripts/build.mjs && rollup -c",
     "test": "echo \"No tests specified\""
   },
   "repository": {
@@ -42,9 +34,6 @@
     "url": "https://github.com/yepistream/sorcherer/issues"
   },
   "homepage": "https://github.com/yepistream/sorcherer#readme",
-  "dependencies": {
-    "three": "^0.152.2"
-  },
   "files": [
     "dist",
     "src",
@@ -53,6 +42,9 @@
   ],
   "unpkg": "dist/sorcherer.umd.min.js",
   "jsdelivr": "dist/sorcherer.umd.min.js",
+  "dependencies": {
+    "three": "^0.152.2"
+  },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",
     "rollup": "^4.35.0"


### PR DESCRIPTION
### Motivation
- Resolve a merge-corrupted `package.json` that left duplicated and conflicting fields and produced an invalid/ambiguous manifest.
- Restore a coherent npm manifest so build/test tools and package consumers see a single consistent configuration.

### Description
- Removed duplicated/merged sections and consolidated `files`, `scripts`, and `main`/`module` entries into a single valid structure. 
- Updated the `build` script to run the dist generator and Rollup in sequence with `node scripts/build.mjs && rollup -c`.
- Re-positioned the `dependencies` block and preserved existing `devDependencies`, `exports`, and publishing metadata.

### Testing
- Ran `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` which succeeded and confirmed valid JSON. 
- Ran `npm test` which executed and returned the repository's test script output successfully. 
- Attempted `npm run build` which fails in this environment because `rollup` is not installed on PATH, while `node scripts/build.mjs` runs successfully on its own.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bc199557483318cd91bf1098d5076)